### PR TITLE
Feature / inline warnings and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Way early still and will most likely be very buggy. Or maybe not start at all. P
 - [x] Goto type by simple typing prefix (like cmd-N in Idea or cmd-shift-T in Eclipse?)
 - [x] Organize imports
 - [ ] Import type at point
-- [ ] Better errors and warnings with markings in gutter
+- [x] Better errors and warnings with markings in gutter
 - [ ] "explicify" applied implicits
 - [ ] Find all subclasses of the class under the cursor
 - [ ] Find all usages of the function under the cursor

--- a/lib/ensime.coffee
+++ b/lib/ensime.coffee
@@ -12,6 +12,7 @@ StatusbarView = require './views/statusbar-view'
 
 ShowTypes = require './features/show-types'
 Implicits = require './features/implicits'
+{InlineErrors, InlineWarnings} = require './features/inline-decorators'
 AutoTypecheck = require './features/auto-typecheck'
 
 TypeCheckingFeature = require './features/typechecking'
@@ -65,16 +66,26 @@ module.exports = Ensime =
       type: 'boolean'
       default: true
       order: 7
+    markErrorsInline:
+      description: "Mark compile errors in the text editor"
+      type: 'boolean'
+      default: true
+      order: 8
+    markWarningsInline:
+      description: "Mark compile warnings in the text editor"
+      type: 'boolean'
+      default: true
+      order: 9
     markImplicitsAutomatically:
       description: "Mark implicits on buffer load and save"
       type: 'boolean'
       default: true
-      order: 8
+      order: 10
     noOfAutocompleteSuggestions:
       description: "Number of autocomplete suggestions requested of server"
       type: 'integer'
       default: 5
-      order: 9
+      order: 11
 
 
 
@@ -118,6 +129,8 @@ module.exports = Ensime =
     # Feature controllers
     @showTypesControllers = new WeakMap
     @implicitControllers = new WeakMap
+    @inlineErrorsControllers = new WeakMap
+    @inlineWarningsControllers = new WeakMap
     @autotypecheckControllers = new WeakMap
 
     @instanceManager = new InstanceManager
@@ -133,6 +146,8 @@ module.exports = Ensime =
         clientLookup = => @instanceManager.instanceOfFile(editor.getPath())?.client
         if atom.config.get('Ensime.enableTypeTooltip')
           if not @showTypesControllers.get(editor) then @showTypesControllers.set(editor, new ShowTypes(editor, clientLookup))
+        if not @inlineErrorsControllers.get(editor) then @inlineErrorsControllers.set(editor, new InlineErrors(editor, clientLookup))
+        if not @inlineWarningsControllers.get(editor) then @inlineWarningsControllers.set(editor, new InlineWarnings(editor, clientLookup))
         if not @implicitControllers.get(editor) then @implicitControllers.set(editor, new Implicits(editor, clientLookup))
         if not @autotypecheckControllers.get(editor) then @autotypecheckControllers.set(editor, new AutoTypecheck(editor, clientLookup))
 
@@ -169,7 +184,7 @@ module.exports = Ensime =
     @clientOfEditor(atom.workspace.getActiveTextEditor())
 
   # TODO: move out
-  statusbarOutput: (statusbarView, typechecking) -> (msg) ->
+  statusbarOutput: (statusbarView, typechecking) -> (msg) =>
     typehint = msg.typehint
 
     if(typehint == 'AnalyzerReadyEvent')
@@ -186,9 +201,15 @@ module.exports = Ensime =
 
     else if(typehint == 'ClearAllScalaNotesEvent')
       typechecking.clearScalaNotes()
+      for e in atom.workspace.getTextEditors()
+        @inlineErrorsControllers.get(e)?.clearScalaNotes()
+        @inlineWarningsControllers.get(e)?.clearScalaNotes()
 
     else if(typehint == 'NewScalaNotesEvent')
       typechecking.addScalaNotes(msg)
+      for e in atom.workspace.getTextEditors()
+        @inlineErrorsControllers.get(e)?.addScalaNotes(msg)
+        @inlineWarningsControllers.get(e)?.addScalaNotes(msg)
 
     else if(typehint.startsWith('SendBackgroundMessageEvent'))
       statusbarView.setText(msg.detail)
@@ -239,6 +260,8 @@ module.exports = Ensime =
 
     deactivateAndDelete(@showTypesControllers)
     deactivateAndDelete(@implicitControllers)
+    deactivateAndDelete(@inlineErrorsControllers)
+    deactivateAndDelete(@inlineWarningsControllers)
     deactivateAndDelete(@autotypecheckControllers)
 
 

--- a/lib/features/implicits.coffee
+++ b/lib/features/implicits.coffee
@@ -3,13 +3,8 @@ SubAtom = require 'sub-atom'
 {log} = require '../utils'
 class Implicits
   constructor: (@editor, @clientLookup) ->
-    # @gutter = @editor.gutterWithName "ensime-implicits"
-    # @gutter ?= @editor.addGutter
-    #   name: "ensime-implicits"
-    #   priority: 10
     @disposables = new SubAtom
 
-    # @handleSetting(atom.config.get('Ensime.markImplicitsAutomatically'))
     @disposables.add atom.config.observe 'Ensime.markImplicitsAutomatically', (setting) => @handleSetting(setting)
 
 
@@ -44,24 +39,25 @@ class Implicits
 
         createMarker = (info) =>
           range = [b.positionForCharacterIndex(parseInt(info.start)), b.positionForCharacterIndex(parseInt(info.end))]
-          marker = @editor.markBufferRange(range,
-              invalidate: 'inside'
+          spot = [range[0], range[0]]
+
+          markerRange = @editor.markBufferRange(range,
               type: 'implicit'
               info: info
           )
-          @editor.decorateMarker(marker,
+          markerSpot = @editor.markBufferRange(spot,
+              type: 'implicit'
+              info: info
+          )
+          @editor.decorateMarker(markerRange,
               type: 'highlight'
               class: 'implicit'
           )
-
-
-          @editor.decorateMarker(marker,
+          @editor.decorateMarker(markerSpot,
               type: 'line-number'
               class: 'implicit'
           )
 
-
-          marker
         markers = (createMarker info for info in result.infos)
       )
     )

--- a/lib/features/inline-decorators.coffee
+++ b/lib/features/inline-decorators.coffee
@@ -1,0 +1,80 @@
+SubAtom = require 'sub-atom'
+{log} = require '../utils'
+class InlineDecorators
+  constructor: (@editor, @client, @type, @hintMatch, @configName) ->
+    @disposables = new SubAtom
+
+    @buffer = @editor.getBuffer()
+
+    @decorators = new WeakMap
+
+    @markers = []
+
+    @show = atom.config.get(@configName)
+
+    @disposables.add atom.config.observe @configName, (setting) => @handleSetting(setting)
+
+  handleSetting: (markInline) ->
+    @show = markInline
+    @updateDecorations()
+
+  addScalaNotes: (msg) ->
+    for note in msg.notes
+      if( note.severity.typehint == @hintMatch && @editor.getPath() == note.file)
+        range = [@buffer.positionForCharacterIndex(parseInt(note.beg)), @buffer.positionForCharacterIndex(parseInt(note.end))]
+        markerRange = @editor.markBufferRange(range,
+          type: @type+"-range"
+        )
+        markerSpot = @editor.markBufferPosition([note.line - 1, note.col - 1],
+          type: @type+"-spot"
+        )
+        marker = { spot: markerSpot, range: markerRange }
+        @markers.push( marker )
+        if(@show)
+          @decorateSpot(marker)
+          @decorateRange(marker)
+
+
+  decorateSpot: (marker) ->
+    @decorators.set(marker.spot, @editor.decorateMarker(marker.spot,
+      type: 'line-number'
+      class: @type
+    ))
+
+  decorateRange: (marker) ->
+    @decorators.set(marker.range, @editor.decorateMarker(marker.range,
+      type: 'highlight'
+      class: @type
+    ))
+
+  updateDecorations: ->
+    for marker in @markers
+      if @show
+        if not @decorators.has(marker.spot) then @decorateSpot(marker)
+        if not @decorators.has(marker.range) then @decorateRange(marker)
+      else
+        @decorators.get(marker.spot)?.destroy()
+        @decorators.delete(marker.spot)
+        @decorators.get(marker.range)?.destroy()
+        @decorators.delete(marker.range)
+
+
+  clearScalaNotes: ->
+    for marker in @markers
+      marker.spot.destroy()
+      marker.range.destroy()
+    @markers = []
+
+  deactivate: ->
+    @disposables.dispose()
+    @clearScalaNotes()
+
+class InlineErrors extends InlineDecorators
+  constructor: (@editor, @client) ->
+    super(@editor, @client, 'error', 'NoteError', 'Ensime.markErrorsInline')
+
+class InlineWarnings extends InlineDecorators
+  constructor: (@editor, @client) ->
+    super(@editor, @client, 'warn', 'NoteWarn', 'Ensime.markWarningsInline')
+
+module.exports = { InlineErrors, InlineWarnings }

--- a/lib/features/typechecking.coffee
+++ b/lib/features/typechecking.coffee
@@ -1,35 +1,15 @@
 {MessagePanelView, LineMessageView} = require 'atom-message-panel'
 _ = require 'lodash'
 {log, isScalaSource} = require '../utils'
-{CompositeDisposable} = require 'atom'
 
-# TODO: Add a map from file -> array[messages] and editor subs
 module.exports =
 class TypeChecking
-
 
   constructor: ->
     @messages = new MessagePanelView
       title: 'Ensime'
     @messages.attach()
 
-    @disposables = new CompositeDisposable
-
-    @editors = new Map
-
-    @markersOfFile = new Map
-
-    @disposables.add atom.workspace.observeTextEditors (editor) =>
-      if isScalaSource(editor) # TODO: check that the source is also in an ensime-activated project.  ensime:start should log which directories are ensime-enabled
-        @editors.set(editor.getPath(), editor)
-        @disposables.add editor.onDidDestroy () =>
-          @editors.delete(editor.getPath())
-
-  hide: ->
-    @messages.hide()
-
-  show: ->
-    @messages.show()
 
   addScalaNotes: (msg) ->
     notes = msg.notes
@@ -53,13 +33,6 @@ class TypeChecking
       if(not file.includes('dep-src')) # TODO: put under flag
         addNoteToMessageView note for note in notes
 
-        # TODO: add markers if editor open
-        if(@editors.has(file))
-          editor = @editors.get(file)
-          for note in notes
-            marker = editor.markBufferPosition([note.line, note.col], {invalidate: 'inside'})
-            editor.decorateMarker(marker, {})
-
 
   clearScalaNotes: ->
     @messages.clear()
@@ -69,8 +42,3 @@ class TypeChecking
     @messages.clear()
     @messages?.close()
     @messages = null
-
-    @markersOfFile = null
-    @editors = null
-
-    @disposables.dispose()

--- a/lib/features/typechecking.coffee
+++ b/lib/features/typechecking.coffee
@@ -18,7 +18,7 @@ class TypeChecking
     @notesByFile = _.groupBy(notes, (note) -> note.file)
 
     addNoteToMessageView = (note) =>
-      file = note.file
+      file = atom.project.relativizePath(note.file)[1]
       @messages.add new LineMessageView
         file: file
         line: note.line

--- a/styles/ensime.atom-text-editor.less
+++ b/styles/ensime.atom-text-editor.less
@@ -1,17 +1,17 @@
 @import "octicon-mixins";
+@import "octicon-utf-codes";
 
-atom-text-editor::shadow {
-  .my-awesome-octicon {
-    .octicon(octoface);
-  }
-}
+@error-class: .error;
+@error-gutter-icon:  @stop;
+@error-gutter-background:  @background-color-error;
+@error-gutter-color: lighten(desaturate(@background-color-error, 50%), 50%);
+@error-underline-color:  fade(@background-color-error, 50%);
 
-
-
-
-
-
-@implicit-color: #09C ;
+@warn-class: .warn;
+@warn-gutter-icon:  @alert;
+@warn-gutter-background:  @background-color-warning;
+@warn-gutter-color: lighten(desaturate(@background-color-warning, 50%), 50%);
+@warn-underline-color:  fade(@background-color-warning, 50%);
 
 .highlight.varField .region {
   color: @syntax-color-variable;
@@ -21,6 +21,29 @@ atom-text-editor::shadow {
   color: @syntax-color-value;
 }
 
+.inline-marker(@name; @underline-color; @gutter-background-color; @gutter-icon; @gutter-icon-color) {
+  .highlight@{name} .region {
+    border-bottom: 1px dashed @underline-color;
+  }
+  .gutter .line-number@{name} {
+    background-color: @gutter-background-color;
+    .icon-right {
+      visibility: visible;
+      &:before {
+        content: @gutter-icon;
+        color: @gutter-icon-color;
+      }
+    }
+  }
+}
+
+atom-text-editor, atom-text-editor::shadow {
+  .inline-marker(@error-class,@error-underline-color, @error-gutter-background,@error-gutter-icon, @error-gutter-color);
+  .inline-marker(@warn-class,@warn-underline-color, @warn-gutter-background,@warn-gutter-icon, @warn-gutter-color);
+}
+
+@implicit-color: #09C ;
+
 .highlight.implicit .region {
   border-bottom: 1px dashed fade(@implicit-color, 70%);
 }
@@ -29,9 +52,6 @@ atom-text-editor::shadow {
 atom-text-editor .gutter[gutter-name="ensime-implicits"] {
   border-left: none;
 }
-
-
-
 
 atom-text-editor .gutter .line-number.implicit .icon-right,
 atom-text-editor::shadow .gutter .line-number.implicit .icon-right {

--- a/styles/ensime.atom-text-editor.less
+++ b/styles/ensime.atom-text-editor.less
@@ -13,6 +13,12 @@
 @warn-gutter-color: lighten(desaturate(@background-color-warning, 50%), 50%);
 @warn-underline-color:  fade(@background-color-warning, 50%);
 
+@implicit-class: .implicit;
+@implicit-gutter-icon:  @info;
+@implicit-gutter-background:  inherit;
+@implicit-gutter-color: @text-color-info;
+@implicit-underline-color: fade(@text-color-info, 50%);
+
 .highlight.varField .region {
   color: @syntax-color-variable;
 }
@@ -38,29 +44,9 @@
 }
 
 atom-text-editor, atom-text-editor::shadow {
+  .inline-marker(@implicit-class,@implicit-underline-color, @implicit-gutter-background,@implicit-gutter-icon, @implicit-gutter-color);
   .inline-marker(@error-class,@error-underline-color, @error-gutter-background,@error-gutter-icon, @error-gutter-color);
   .inline-marker(@warn-class,@warn-underline-color, @warn-gutter-background,@warn-gutter-icon, @warn-gutter-color);
-}
-
-@implicit-color: #09C ;
-
-.highlight.implicit .region {
-  border-bottom: 1px dashed fade(@implicit-color, 70%);
-}
-
-// Styles for ensime gutter, don't know if we should really have one
-atom-text-editor .gutter[gutter-name="ensime-implicits"] {
-  border-left: none;
-}
-
-atom-text-editor .gutter .line-number.implicit .icon-right,
-atom-text-editor::shadow .gutter .line-number.implicit .icon-right {
-  visibility: visible;
-}
-atom-text-editor .gutter .line-number.implicit .icon-right:before,
-atom-text-editor::shadow .gutter .line-number.implicit .icon-right:before {
-  content: "\f087";
-  color: #09C;
 }
 
 implicit-info.select-list.popover-list {


### PR DESCRIPTION
This pull request adds inline error/warning underlines and gutter markings. 

By way of gif:
![demo-inlines](https://cloud.githubusercontent.com/assets/6980603/11697315/0b5312a0-9e87-11e5-8263-9621628f62ac.gif)

Implicit markers were also cleaned-up a bit, bringing the styling into-line with the errors/warnings.

I made a decision to put the message dispatching into the main ensime controller in the `statusbarOutput` method, knowing that the intention is to pull out this functionality into a separate concern—i.e. some sort of "central dispatch". I viewed this as a better move than adding complication to the `TypeChecking` class, which seems best suited to controlling the bottom pane view for now. 

If that decision turns out to be controversial, I'm happy to push the dispatch back into the `TypeChecking` class.
